### PR TITLE
fix Mixed Content error for jqueryCompleteDemo

### DIFF
--- a/_examples/jqueryCompleteDemo.html
+++ b/_examples/jqueryCompleteDemo.html
@@ -4,7 +4,7 @@
 <head>
     <title>使用jquery的完整demo</title>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
-    <script src="http://ajax.aspnetcdn.com/ajax/jQuery/jquery-1.8.3.min.js" charset=""></script>
+    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-1.8.3.min.js" charset=""></script>
     <script type="text/javascript" charset="utf-8" src="../ueditor.config.js"></script>
     <script type="text/javascript" charset="utf-8" src="editor_api.js"></script>
     <script>


### PR DESCRIPTION
fix error Mixed Content:
```
Mixed Content: The page at 'https://open-demo.modstart.com/ueditor-plus/_examples/' was loaded over HTTPS, but requested an insecure script 'http://ajax.aspnetcdn.com/ajax/jQuery/jquery-1.8.3.min.js'. This request has been blocked; the content must be served over HTTPS.
```